### PR TITLE
Task 1

### DIFF
--- a/format.go
+++ b/format.go
@@ -13,15 +13,6 @@ const (
 	JSON
 )
 
-// Levels
-const (
-	debugLevel = "DEBUG"
-	errLevel   = "ERROR"
-	fatalLevel = "FATAL"
-	infoLevel  = "INFO"
-	warnLevel  = "WARN"
-)
-
 // formatTime defines how log entry time stamps are formatted.
 const formatTime = "2006/01/02 15:04:05"
 

--- a/level.go
+++ b/level.go
@@ -2,9 +2,12 @@ package logger
 
 // Levels
 const (
-	debugLevel = "DEBUG"
-	errLevel   = "ERROR"
-	fatalLevel = "FATAL"
-	infoLevel  = "INFO"
-	warnLevel  = "WARN"
+	debugLevel Level = "DEBUG"
+	errLevel   Level = "ERROR"
+	fatalLevel Level = "FATAL"
+	infoLevel  Level = "INFO"
+	warnLevel  Level = "WARN"
 )
+
+// A Level indicates the significance of a log entry.
+type Level string

--- a/level.go
+++ b/level.go
@@ -1,0 +1,10 @@
+package logger
+
+// Levels
+const (
+	debugLevel = "DEBUG"
+	errLevel   = "ERROR"
+	fatalLevel = "FATAL"
+	infoLevel  = "INFO"
+	warnLevel  = "WARN"
+)

--- a/logger.go
+++ b/logger.go
@@ -91,7 +91,7 @@ func (lgr *Logger) Warn(message string) {
 }
 
 // write writes a leveled message to the underlying writer.
-func (lgr *Logger) write(level, message string) {
+func (lgr *Logger) write(level Level, message string) {
 	lgr.Lock()
 	lgr.Write([]byte(fmt.Sprintf(formats[lgr.format], time.Now().Format(formatTime), level, message)))
 	lgr.Unlock()


### PR DESCRIPTION
### Description

This change moves levels from format.go to level.go and adds the level type alias.

[Logger board](https://trello.com/b/iTsmDTDY/logger)
[Task 1](https://trello.com/c/6kjSfF7q)
