### PR TITLE
Task 2

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -12,7 +12,7 @@ import (
 // A Logger writes formatted messages to a writer.
 type Logger struct {
 	sync.Mutex
-	io.Writer
+	output io.Writer
 	format Format
 }
 
@@ -35,7 +35,7 @@ func (lgr *Logger) Init(opts ...Option) {
 		opt(lgr)
 	}
 
-	if lgr.Writer == nil {
+	if lgr.output == nil {
 		lgr.SetWriter(os.Stderr)
 	}
 }
@@ -50,7 +50,7 @@ func (lgr *Logger) SetFormat(n Format) {
 // SetWriter sets the underlying writer.
 func (lgr *Logger) SetWriter(w io.Writer) {
 	lgr.Lock()
-	lgr.Writer = w
+	lgr.output = w
 	lgr.Unlock()
 }
 
@@ -74,6 +74,13 @@ func (lgr *Logger) Info(message string) {
 	lgr.write(infoLevel, message)
 }
 
+// Output returns the underlying writer.
+func (lgr *Logger) Output() io.Writer {
+	lgr.Lock()
+	defer lgr.Unlock()
+	return lgr.output
+}
+
 // Panic writes an error, then calls panic.
 func (lgr *Logger) Panic(message string) {
 	lgr.Error(message)
@@ -93,6 +100,6 @@ func (lgr *Logger) Warn(message string) {
 // write writes a leveled message to the underlying writer.
 func (lgr *Logger) write(level Level, message string) {
 	lgr.Lock()
-	lgr.Write([]byte(fmt.Sprintf(formats[lgr.format], time.Now().Format(formatTime), level, message)))
+	lgr.output.Write([]byte(fmt.Sprintf(formats[lgr.format], time.Now().Format(formatTime), level, message)))
 	lgr.Unlock()
 }

--- a/logger.go
+++ b/logger.go
@@ -36,7 +36,7 @@ func (lgr *Logger) Init(opts ...Option) {
 	}
 
 	if lgr.output == nil {
-		lgr.SetWriter(os.Stderr)
+		lgr.SetOutput(os.Stderr)
 	}
 }
 
@@ -47,8 +47,8 @@ func (lgr *Logger) SetFormat(n Format) {
 	lgr.Unlock()
 }
 
-// SetWriter sets the underlying writer.
-func (lgr *Logger) SetWriter(w io.Writer) {
+// SetOutput sets the underlying writer.
+func (lgr *Logger) SetOutput(w io.Writer) {
 	lgr.Lock()
 	lgr.output = w
 	lgr.Unlock()

--- a/logger_test.go
+++ b/logger_test.go
@@ -28,7 +28,7 @@ func TestJSON(t *testing.T) {
 
 	lgr.Init(
 		SetFormat(JSON),
-		SetWriter(f),
+		SetOutput(f),
 	)
 
 	lgr.Info("Hello, World!")

--- a/option.go
+++ b/option.go
@@ -12,8 +12,8 @@ func SetFormat(n Format) Option {
 	}
 }
 
-// SetWriter returns an option that can set the writer for a logger.
-func SetWriter(w io.Writer) Option {
+// SetOutput returns an option that can set the writer for a logger.
+func SetOutput(w io.Writer) Option {
 	return func(lgr *Logger) {
 		lgr.SetOutput(w)
 	}

--- a/option.go
+++ b/option.go
@@ -15,6 +15,6 @@ func SetFormat(n Format) Option {
 // SetWriter returns an option that can set the writer for a logger.
 func SetWriter(w io.Writer) Option {
 	return func(lgr *Logger) {
-		lgr.SetWriter(w)
+		lgr.SetOutput(w)
 	}
 }


### PR DESCRIPTION
### Description

This change removes the exposure of the underlying writer. The writer is now a hidden field called `output io.Writer`.

[Task 2](https://trello.com/c/n0mEPYna)
[Logger board](https://trello.com/b/iTsmDTDY/logger)
