### PR TITLE
switch to r/w mutex; use read-lock on getters

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -11,7 +11,7 @@ import (
 
 // A Logger writes formatted messages to a writer.
 type Logger struct {
-	sync.Mutex
+	sync.RWMutex
 	output io.Writer
 	format Format
 }
@@ -76,16 +76,16 @@ func (lgr *Logger) Info(message string) {
 
 // Output returns the underlying writer.
 func (lgr *Logger) Output() io.Writer {
-	lgr.Lock()
-	defer lgr.Unlock()
+	lgr.RLock()
+	defer lgr.RUnlock()
 	return lgr.output
 }
 
 // outputIs determines if the underlying writer is equal to the given
 // writer.
 func (lgr *Logger) outputIs(w io.Writer) bool {
-	lgr.Lock()
-	defer lgr.Unlock()
+	lgr.RLock()
+	defer lgr.RUnlock()
 	return lgr.output == w
 }
 


### PR DESCRIPTION
### Description

This change switches the mutex to a read/write mutex.

[Task 11](https://trello.com/c/IuzFANEo/12-task-11-switch-the-mutex-to-a-read-write-mutex)
[Logger board](https://trello.com/b/iTsmDTDY/logger)
